### PR TITLE
Fixed selection lost on scrolling, and navigation back to login

### DIFF
--- a/app/src/main/java/com/example/attendencemonitor/activity/auth/LoginActivity.java
+++ b/app/src/main/java/com/example/attendencemonitor/activity/auth/LoginActivity.java
@@ -72,7 +72,9 @@ public class LoginActivity extends BaseMenuActivity
         public void onSuccess()
         {
             //start App-Session
-            startActivity(new Intent(LoginActivity.this, SessionActivity.class));
+            Intent intent = new Intent(LoginActivity.this, SessionActivity.class);
+            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+            startActivity(intent);
         }
 
         @Override

--- a/app/src/main/java/com/example/attendencemonitor/activity/module/timeslot/TimeslotFragment.java
+++ b/app/src/main/java/com/example/attendencemonitor/activity/module/timeslot/TimeslotFragment.java
@@ -233,7 +233,7 @@ public class TimeslotFragment extends Fragment implements DatePickerDialog.OnDat
         RecyclerView rv = getActivity().findViewById(R.id.rv_timeslot_list);
         rv.setHasFixedSize(true);
         LinearLayoutManager lm = new LinearLayoutManager(getActivity());
-        adapter = new TimeslotListAdapter(timeslotList, new ListItemListener());
+        adapter = new TimeslotListAdapter(filter(searchBox.getText().toString()), new ListItemListener());
 
         rv.setLayoutManager(lm);
         rv.setAdapter(adapter);

--- a/app/src/main/java/com/example/attendencemonitor/activity/user/UserListAdapter.java
+++ b/app/src/main/java/com/example/attendencemonitor/activity/user/UserListAdapter.java
@@ -60,18 +60,7 @@ public class UserListAdapter extends RecyclerView.Adapter<UserListAdapter.UserLi
         holder.tv_usermail.setText(currentItem.getMail());
         holder.tv_code.setText(currentItem.getCode());
 
-        //setup check radio button or checkbox depending on single or multi selection
-        if(isSingleSelection){
-            holder.cb_selected.setVisibility(View.GONE);
-            holder.rb_selected.setVisibility(View.VISIBLE);
-            holder.rb_selected.setChecked(currentSelection.stream().anyMatch(o -> o.getId() == currentItem.getId()));
-        }
-        else{
-            holder.rb_selected.setVisibility(View.GONE);
-            holder.cb_selected.setVisibility(View.VISIBLE);
-            holder.cb_selected.setChecked(currentSelection.stream().anyMatch(o -> o.getId() == currentItem.getId()));
-        }
-
+        //Must be before loading values, otherwise selection will get lost on scrolling
         holder.rb_selected.setOnCheckedChangeListener((compoundButton, b) -> {
             currentSelection.clear();
             currentSelection.add(currentItem);
@@ -87,9 +76,23 @@ public class UserListAdapter extends RecyclerView.Adapter<UserListAdapter.UserLi
                 currentSelection.add(currentItem);
             }
             else{
-                currentSelection.removeIf(u -> u.getId() == currentItem.getId());
+                int id = currentItem.getId();
+                currentSelection.removeIf(u -> u.getId() == id);
             }
         });
+
+        //setup check radio button or checkbox depending on single or multi selection
+        if(isSingleSelection){
+            holder.cb_selected.setVisibility(View.GONE);
+            holder.rb_selected.setVisibility(View.VISIBLE);
+            holder.rb_selected.setChecked(currentSelection.stream().anyMatch(o -> o.getId() == currentItem.getId()));
+        }
+        else{
+            holder.rb_selected.setVisibility(View.GONE);
+            holder.cb_selected.setVisibility(View.VISIBLE);
+            boolean isChecked = currentSelection.stream().anyMatch(o -> o.getId() == currentItem.getId());
+            holder.cb_selected.setChecked(isChecked);
+        }
 
         //forwarding events to the event listener
         holder.userContainer.setOnClickListener(view -> {

--- a/app/src/main/java/com/example/attendencemonitor/activity/user/UserListAdapter.java
+++ b/app/src/main/java/com/example/attendencemonitor/activity/user/UserListAdapter.java
@@ -62,6 +62,7 @@ public class UserListAdapter extends RecyclerView.Adapter<UserListAdapter.UserLi
 
         //Must be before loading values, otherwise selection will get lost on scrolling
         holder.rb_selected.setOnCheckedChangeListener((compoundButton, b) -> {
+            if(!b) return;
             currentSelection.clear();
             currentSelection.add(currentItem);
             try{


### PR DESCRIPTION
Fixed Bug where scrolling Student selection on module form, would result in losing the current selection.

Fixe bug where the user was able to navigate back to the login immidiately after logging in, using the back button on his phone